### PR TITLE
Manually push script args onto process

### DIFF
--- a/lib/internal/main/run_third_party_main.js
+++ b/lib/internal/main/run_third_party_main.js
@@ -6,6 +6,6 @@ prepareMainThreadExecution();
 
 markBootstrapComplete();
 // @ssd - third_party_main does not normally get argv populated, add arguments to argv array
-process.argv.push(process.argv[0], ...process.execArgv);
+process.argv.splice(1, 0, process.argv[0], process.argv[0], ...process.execArgv);
 
 require('_third_party_main');


### PR DESCRIPTION
_third_party_main processing doesn't handle args properly, this fixes the issue so that uncompiled and compiled apps perform the same way.